### PR TITLE
add selectCanRequest and selectShouldRequest selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ dist
 
 # Api Extractor temp files
 temp
+
+.npmrc

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/

--- a/packages/redux-slice-factory/etc/redux-slice-factory.api.json
+++ b/packages/redux-slice-factory/etc/redux-slice-factory.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.2",
+    "toolVersion": "7.13.0",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },
@@ -446,6 +446,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": true,
               "releaseTag": "Public",
               "name": "debug",
               "propertyTypeTokenRange": {
@@ -485,6 +486,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": true,
               "releaseTag": "Public",
               "name": "initialState",
               "propertyTypeTokenRange": {
@@ -510,6 +512,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "name",
               "propertyTypeTokenRange": {
@@ -540,11 +543,47 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "selectId",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 3
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@gjv/redux-slice-factory!ICreateEntitySliceOptions#selectShouldRequest:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "selectShouldRequest?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(sliceState: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "IEntityState",
+                  "canonicalReference": "@gjv/redux-slice-factory!IEntityState:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<TEntity, TStatusEnum, TError>) => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "selectShouldRequest",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
               }
             },
             {
@@ -574,6 +613,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "selectSliceState",
               "propertyTypeTokenRange": {
@@ -608,6 +648,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "sortComparer",
               "propertyTypeTokenRange": {
@@ -747,6 +788,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": true,
               "releaseTag": "Public",
               "name": "debug",
               "propertyTypeTokenRange": {
@@ -786,6 +828,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": true,
               "releaseTag": "Public",
               "name": "initialState",
               "propertyTypeTokenRange": {
@@ -811,11 +854,47 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "name",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@gjv/redux-slice-factory!ICreateModelSliceOptions#selectShouldRequest:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "selectShouldRequest?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(sliceState: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "IModelState",
+                  "canonicalReference": "@gjv/redux-slice-factory!IModelState:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<TModel, TStatusEnum, TError>) => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "selectShouldRequest",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
               }
             },
             {
@@ -845,6 +924,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "selectSliceState",
               "propertyTypeTokenRange": {
@@ -1988,6 +2068,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "selectError",
               "propertyTypeTokenRange": {
@@ -2013,6 +2094,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "selectLastHydrated",
               "propertyTypeTokenRange": {
@@ -2038,6 +2120,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "selectLastModified",
               "propertyTypeTokenRange": {
@@ -2063,6 +2146,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "selectStatus",
               "propertyTypeTokenRange": {
@@ -2180,6 +2264,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "error",
               "propertyTypeTokenRange": {
@@ -2205,6 +2290,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "lastHydrated",
               "propertyTypeTokenRange": {
@@ -2230,6 +2316,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "lastModified",
               "propertyTypeTokenRange": {
@@ -2255,6 +2342,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "status",
               "propertyTypeTokenRange": {
@@ -2758,7 +2846,34 @@
             }
           ],
           "name": "IModelSliceSelectors",
-          "members": [],
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@gjv/redux-slice-factory!IModelSliceSelectors#selectModel:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "selectModel: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(state: TGlobalState) => TModel"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "selectModel",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
           "extendsTokenRanges": [
             {
               "startIndex": 13,
@@ -2897,6 +3012,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "model",
               "propertyTypeTokenRange": {
@@ -3020,6 +3136,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "actions",
               "propertyTypeTokenRange": {
@@ -3045,6 +3162,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "name",
               "propertyTypeTokenRange": {
@@ -3075,6 +3193,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "reducer",
               "propertyTypeTokenRange": {
@@ -3100,6 +3219,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "selectors",
               "propertyTypeTokenRange": {
@@ -3149,6 +3269,32 @@
           "members": [
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@gjv/redux-slice-factory!ISliceSelectors#selectShouldRequest:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "selectShouldRequest?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(state: TGlobalState) => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "selectShouldRequest",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@gjv/redux-slice-factory!ISliceSelectors#selectSliceState:member",
               "docComment": "",
               "excerptTokens": [
@@ -3165,6 +3311,7 @@
                   "text": ";"
                 }
               ],
+              "isOptional": false,
               "releaseTag": "Public",
               "name": "selectSliceState",
               "propertyTypeTokenRange": {

--- a/packages/redux-slice-factory/etc/redux-slice-factory.api.json
+++ b/packages/redux-slice-factory/etc/redux-slice-factory.api.json
@@ -522,6 +522,41 @@
             },
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@gjv/redux-slice-factory!ICreateEntitySliceOptions#selectCanRequest:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "selectCanRequest?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(sliceState: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "IEntityState",
+                  "canonicalReference": "@gjv/redux-slice-factory!IEntityState:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<TEntity, TStatusEnum, TError>) => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "selectCanRequest",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@gjv/redux-slice-factory!ICreateEntitySliceOptions#selectId:member",
               "docComment": "",
               "excerptTokens": [
@@ -571,7 +606,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<TEntity, TStatusEnum, TError>) => boolean"
+                  "text": "<TEntity, TStatusEnum, TError>, canRequest: boolean) => boolean"
                 },
                 {
                   "kind": "Content",
@@ -864,6 +899,41 @@
             },
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@gjv/redux-slice-factory!ICreateModelSliceOptions#selectCanRequest:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "selectCanRequest?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(sliceState: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "IModelState",
+                  "canonicalReference": "@gjv/redux-slice-factory!IModelState:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<TModel, TStatusEnum, TError>) => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "selectCanRequest",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@gjv/redux-slice-factory!ICreateModelSliceOptions#selectShouldRequest:member",
               "docComment": "",
               "excerptTokens": [
@@ -882,7 +952,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "<TModel, TStatusEnum, TError>) => boolean"
+                  "text": "<TModel, TStatusEnum, TError>, canRequest: boolean) => boolean"
                 },
                 {
                   "kind": "Content",
@@ -3267,6 +3337,32 @@
           ],
           "name": "ISliceSelectors",
           "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@gjv/redux-slice-factory!ISliceSelectors#selectCanRequest:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "selectCanRequest?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(state: TGlobalState) => boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "selectCanRequest",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
             {
               "kind": "PropertySignature",
               "canonicalReference": "@gjv/redux-slice-factory!ISliceSelectors#selectShouldRequest:member",

--- a/packages/redux-slice-factory/etc/redux-slice-factory.api.md
+++ b/packages/redux-slice-factory/etc/redux-slice-factory.api.md
@@ -30,9 +30,11 @@ export interface ICreateEntitySliceOptions<TGlobalState, TEntity, TStatusEnum ex
     // (undocumented)
     name: string;
     // (undocumented)
+    selectCanRequest?: (sliceState: IEntityState<TEntity, TStatusEnum, TError>) => boolean;
+    // (undocumented)
     selectId: (o: TEntity) => EntityId;
     // (undocumented)
-    selectShouldRequest?: (sliceState: IEntityState<TEntity, TStatusEnum, TError>) => boolean;
+    selectShouldRequest?: (sliceState: IEntityState<TEntity, TStatusEnum, TError>, canRequest: boolean) => boolean;
     // (undocumented)
     selectSliceState: (state: TGlobalState) => IEntityState<TEntity, TStatusEnum, TError>;
     // (undocumented)
@@ -48,7 +50,9 @@ export interface ICreateModelSliceOptions<TGlobalState, TModel, TStatusEnum exte
     // (undocumented)
     name: string;
     // (undocumented)
-    selectShouldRequest?: (sliceState: IModelState<TModel, TStatusEnum, TError>) => boolean;
+    selectCanRequest?: (sliceState: IModelState<TModel, TStatusEnum, TError>) => boolean;
+    // (undocumented)
+    selectShouldRequest?: (sliceState: IModelState<TModel, TStatusEnum, TError>, canRequest: boolean) => boolean;
     // (undocumented)
     selectSliceState: (state: TGlobalState) => IModelState<TModel, TStatusEnum, TError>;
 }
@@ -147,6 +151,8 @@ export interface ISlice<TGlobalState, TSliceState, TCaseReducers extends SliceCa
 
 // @public (undocumented)
 export interface ISliceSelectors<TGlobalState, TSliceState> {
+    // (undocumented)
+    selectCanRequest?: (state: TGlobalState) => boolean;
     // (undocumented)
     selectShouldRequest?: (state: TGlobalState) => boolean;
     // (undocumented)

--- a/packages/redux-slice-factory/etc/redux-slice-factory.api.md
+++ b/packages/redux-slice-factory/etc/redux-slice-factory.api.md
@@ -32,6 +32,8 @@ export interface ICreateEntitySliceOptions<TGlobalState, TEntity, TStatusEnum ex
     // (undocumented)
     selectId: (o: TEntity) => EntityId;
     // (undocumented)
+    selectShouldRequest?: (sliceState: IEntityState<TEntity, TStatusEnum, TError>) => boolean;
+    // (undocumented)
     selectSliceState: (state: TGlobalState) => IEntityState<TEntity, TStatusEnum, TError>;
     // (undocumented)
     sortComparer: false | Comparer<TEntity>;
@@ -45,6 +47,8 @@ export interface ICreateModelSliceOptions<TGlobalState, TModel, TStatusEnum exte
     initialState?: Partial<IModelState<TModel, TStatusEnum, TError>>;
     // (undocumented)
     name: string;
+    // (undocumented)
+    selectShouldRequest?: (sliceState: IModelState<TModel, TStatusEnum, TError>) => boolean;
     // (undocumented)
     selectSliceState: (state: TGlobalState) => IModelState<TModel, TStatusEnum, TError>;
 }
@@ -143,6 +147,8 @@ export interface ISlice<TGlobalState, TSliceState, TCaseReducers extends SliceCa
 
 // @public (undocumented)
 export interface ISliceSelectors<TGlobalState, TSliceState> {
+    // (undocumented)
+    selectShouldRequest?: (state: TGlobalState) => boolean;
     // (undocumented)
     selectSliceState: (state: TGlobalState) => TSliceState;
 }

--- a/packages/redux-slice-factory/src/slice-factories/create-entity-slice/CreateEntitySlice.test.ts
+++ b/packages/redux-slice-factory/src/slice-factories/create-entity-slice/CreateEntitySlice.test.ts
@@ -54,7 +54,7 @@ describe('createEntitySlice', () => {
         expect(slice.name).toEqual(testName)
         expect(typeof slice.reducer).toEqual('function')
         expect(Object.values(slice.actions)).toHaveLength(16)
-        expect(Object.values(slice.selectors)).toHaveLength(10)
+        expect(Object.values(slice.selectors)).toHaveLength(11)
     })
 
     it('does not affect state with unregistered action types', () => {

--- a/packages/redux-slice-factory/src/slice-factories/create-entity-slice/CreateEntitySlice.test.ts
+++ b/packages/redux-slice-factory/src/slice-factories/create-entity-slice/CreateEntitySlice.test.ts
@@ -54,7 +54,7 @@ describe('createEntitySlice', () => {
         expect(slice.name).toEqual(testName)
         expect(typeof slice.reducer).toEqual('function')
         expect(Object.values(slice.actions)).toHaveLength(16)
-        expect(Object.values(slice.selectors)).toHaveLength(11)
+        expect(Object.values(slice.selectors)).toHaveLength(12)
     })
 
     it('does not affect state with unregistered action types', () => {

--- a/packages/redux-slice-factory/src/slice-factories/create-entity-slice/CreateEntitySlice.ts
+++ b/packages/redux-slice-factory/src/slice-factories/create-entity-slice/CreateEntitySlice.ts
@@ -80,7 +80,8 @@ export interface ICreateEntitySliceOptions<
     selectSliceState: (state: TGlobalState) => IEntityState<TEntity, TStatusEnum, TError>;
     selectId: (o: TEntity) => EntityId;
     sortComparer: false | Comparer<TEntity>;
-    selectShouldRequest?: (sliceState: IEntityState<TEntity, TStatusEnum, TError>) => boolean;
+    selectCanRequest?: (sliceState: IEntityState<TEntity, TStatusEnum, TError>) => boolean;
+    selectShouldRequest?: (sliceState: IEntityState<TEntity, TStatusEnum, TError>, canRequest: boolean) => boolean;
     initialState?: Partial<IEntityState<TEntity, TStatusEnum, TError>>;
     debug?: boolean;
 }
@@ -96,7 +97,13 @@ function createEntitySlice<
 >(options: ICreateEntitySliceOptions<TGlobalState, TEntity, TStatusEnum, TError>): IEntitySlice<TGlobalState, TEntity, TStatusEnum, TError> {
     type ISliceState = IEntityState<TEntity, TStatusEnum, TError>
 
-    const { name, selectSliceState, selectId, sortComparer, selectShouldRequest, initialState, debug } = options
+    const defaultCanRequestSelector = (sliceState: ISliceState): boolean => sliceState.status !== StatusEnum.Requesting
+        && sliceState.error === null
+        && sliceState.lastModified === null
+
+    const defaultShouldRequestSelector = (sliceState: ISliceState, canRequest: boolean): boolean => canRequest && sliceState.lastHydrated === null
+
+    const { name, selectSliceState, selectId, sortComparer, selectShouldRequest = defaultShouldRequestSelector, selectCanRequest = defaultCanRequestSelector, initialState, debug } = options
 
     // intentional, necessary with immer
     /* eslint-disable no-param-reassign */
@@ -210,14 +217,6 @@ function createEntitySlice<
     })
 
     const entitySelectors = entityAdapter.getSelectors((state: TGlobalState) => selectSliceState(state))
-
-    const shouldRequestSelector = createSelector(selectSliceState, (sliceState) => (selectShouldRequest
-        ? selectShouldRequest(sliceState)
-        : sliceState.status !== StatusEnum.Requesting
-        && sliceState.lastHydrated === null
-        && sliceState.error === null
-        && sliceState.lastModified === null))
-
     const selectors: IEntitySliceSelectors<TGlobalState, TEntity, TStatusEnum, TError> = {
         selectIds: entitySelectors.selectIds,
         selectEntities: entitySelectors.selectEntities,
@@ -229,7 +228,8 @@ function createEntitySlice<
         selectError: createSelector(selectSliceState, (sliceState) => sliceState.error),
         selectLastModified: createSelector(selectSliceState, (sliceState) => sliceState.lastModified),
         selectLastHydrated: createSelector(selectSliceState, (sliceState) => sliceState.lastHydrated),
-        selectShouldRequest: shouldRequestSelector,
+        selectCanRequest: createSelector(selectSliceState, (sliceState) => selectCanRequest(sliceState)),
+        selectShouldRequest: createSelector(selectSliceState, (sliceState) => selectShouldRequest(sliceState, selectCanRequest(sliceState))),
     }
 
     const entitySlice: IEntitySlice<TGlobalState, TEntity, TStatusEnum, TError> = {

--- a/packages/redux-slice-factory/src/slice-factories/create-model-slice/CreateModelSlice.test.ts
+++ b/packages/redux-slice-factory/src/slice-factories/create-model-slice/CreateModelSlice.test.ts
@@ -52,7 +52,7 @@ describe('createModelSlice', () => {
         expect(slice.name).toEqual(testName)
         expect(typeof slice.reducer).toEqual('function')
         expect(Object.values(slice.actions)).toHaveLength(6)
-        expect(Object.values(slice.selectors)).toHaveLength(7)
+        expect(Object.values(slice.selectors)).toHaveLength(8)
     })
 
     it('does not affect state with unregistered action types', () => {

--- a/packages/redux-slice-factory/src/slice-factories/create-model-slice/CreateModelSlice.test.ts
+++ b/packages/redux-slice-factory/src/slice-factories/create-model-slice/CreateModelSlice.test.ts
@@ -52,7 +52,7 @@ describe('createModelSlice', () => {
         expect(slice.name).toEqual(testName)
         expect(typeof slice.reducer).toEqual('function')
         expect(Object.values(slice.actions)).toHaveLength(6)
-        expect(Object.values(slice.selectors)).toHaveLength(6)
+        expect(Object.values(slice.selectors)).toHaveLength(7)
     })
 
     it('does not affect state with unregistered action types', () => {

--- a/packages/redux-slice-factory/src/types/index.ts
+++ b/packages/redux-slice-factory/src/types/index.ts
@@ -9,6 +9,7 @@ export interface ISliceSelectors<
     TSliceState
 > {
     selectSliceState: (state: TGlobalState) => TSliceState;
+    selectShouldRequest?: (state: TGlobalState) => boolean
 }
 
 /**

--- a/packages/redux-slice-factory/src/types/index.ts
+++ b/packages/redux-slice-factory/src/types/index.ts
@@ -9,6 +9,7 @@ export interface ISliceSelectors<
     TSliceState
 > {
     selectSliceState: (state: TGlobalState) => TSliceState;
+    selectCanRequest?: (state: TGlobalState) => boolean;
     selectShouldRequest?: (state: TGlobalState) => boolean
 }
 


### PR DESCRIPTION
Ability to configure a slice to construct a selector that returns whether it needs to fetch data, or fallback to a default behavior