### PR TITLE
Improvements

### DIFF
--- a/packages/redux-slice-factory/package.json
+++ b/packages/redux-slice-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gjv/redux-slice-factory",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Generic factory functions for common slice data structures",
   "author": "Greg Valentine <gregjoeval@gmail.com>",
   "homepage": "https://github.com/gregjoeval/package-library#readme",

--- a/packages/redux-slice-factory/src/models/entity-state/EntityState.ts
+++ b/packages/redux-slice-factory/src/models/entity-state/EntityState.ts
@@ -1,4 +1,4 @@
-import { EntityState as ReduxEntityState } from '@reduxjs/toolkit'
+import { EntityState as ReduxEntityState, SerializedError } from '@reduxjs/toolkit'
 import StatusEnum from '../../constants/StatusEnum'
 import MetaState, { IMetaState } from '../meta-state'
 
@@ -8,13 +8,13 @@ import MetaState, { IMetaState } from '../meta-state'
 export interface IEntityState<
     T,
     TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
+    TError extends SerializedError = SerializedError
 > extends ReduxEntityState<T>, IMetaState<TStatusEnum, TError> {}
 
 const create = <
     T,
     TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
+    TError extends SerializedError = SerializedError
 > (args: Partial<IEntityState<T, TStatusEnum, TError>> = {}): IEntityState<T, TStatusEnum, TError> => {
     const metaState = MetaState.create(args)
     return {

--- a/packages/redux-slice-factory/src/models/meta-state/MetaState.ts
+++ b/packages/redux-slice-factory/src/models/meta-state/MetaState.ts
@@ -1,9 +1,10 @@
+import { CaseReducer, PayloadAction, SerializedError } from '@reduxjs/toolkit'
 import StatusEnum from '../../constants/StatusEnum'
 
 /**
  * @public
  */
-export interface IMetaState <TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum, TError extends Error = Error> {
+export interface IMetaState <TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum, TError extends SerializedError = SerializedError> {
     status: TStatusEnum;
     error: TError | null;
     lastModified: string | null;
@@ -12,7 +13,7 @@ export interface IMetaState <TStatusEnum extends keyof typeof StatusEnum | & str
 
 const create = <
     TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
+    TError extends SerializedError = SerializedError
 > (args: Partial<IMetaState<TStatusEnum, TError>> = {}): IMetaState<TStatusEnum, TError> => ({
     status: args.status ?? StatusEnum.Settled as TStatusEnum,
     error: args.error ?? null,

--- a/packages/redux-slice-factory/src/models/model-state/ModelState.ts
+++ b/packages/redux-slice-factory/src/models/model-state/ModelState.ts
@@ -1,3 +1,4 @@
+import { SerializedError } from '@reduxjs/toolkit'
 import StatusEnum from '../../constants/StatusEnum'
 import MetaState, { IMetaState } from '../meta-state'
 
@@ -7,7 +8,7 @@ import MetaState, { IMetaState } from '../meta-state'
 export interface IModelState<
     T,
     TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
+    TError extends SerializedError = SerializedError
 > extends IMetaState<TStatusEnum, TError> {
     model: T;
 }
@@ -15,7 +16,7 @@ export interface IModelState<
 const create = <
     T,
     TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
+    TError extends SerializedError = SerializedError
 > (args: Partial<IModelState<T, TStatusEnum, TError>> = {}): IModelState<T, TStatusEnum, TError> => {
     const metaState = MetaState.create(args)
     return {

--- a/packages/redux-slice-factory/src/slice-factories/create-entity-slice/CreateEntitySlice.test.ts
+++ b/packages/redux-slice-factory/src/slice-factories/create-entity-slice/CreateEntitySlice.test.ts
@@ -53,7 +53,7 @@ describe('createEntitySlice', () => {
     it('initializes', () => {
         expect(slice.name).toEqual(testName)
         expect(typeof slice.reducer).toEqual('function')
-        expect(Object.values(slice.actions)).toHaveLength(16)
+        expect(Object.values(slice.actions)).toHaveLength(18)
         expect(Object.values(slice.selectors)).toHaveLength(12)
     })
 
@@ -74,7 +74,7 @@ describe('createEntitySlice', () => {
         const error = new Error('this was a test')
 
         // WHEN
-        const nextState = slice.reducer(sliceState, slice.actions.setError(mapErrorToSerializableObject(error)))
+        const nextState = slice.reducer(sliceState, slice.actions.setError(error))
 
         // THEN
         expect(nextState.ids).toEqual(previousState.ids) // should be unaffected

--- a/packages/redux-slice-factory/src/slice-factories/create-model-slice/CreateModelSlice.test.ts
+++ b/packages/redux-slice-factory/src/slice-factories/create-model-slice/CreateModelSlice.test.ts
@@ -51,7 +51,7 @@ describe('createModelSlice', () => {
     it('initializes', () => {
         expect(slice.name).toEqual(testName)
         expect(typeof slice.reducer).toEqual('function')
-        expect(Object.values(slice.actions)).toHaveLength(6)
+        expect(Object.values(slice.actions)).toHaveLength(8)
         expect(Object.values(slice.selectors)).toHaveLength(8)
     })
 
@@ -72,7 +72,7 @@ describe('createModelSlice', () => {
         const error = new Error('this was a test')
 
         // WHEN
-        const nextState = slice.reducer(sliceState, slice.actions.setError(mapErrorToSerializableObject(error)))
+        const nextState = slice.reducer(sliceState, slice.actions.setError(error))
 
         // THEN
         expect(nextState.model).toEqual(previousState.model) // should be unaffected

--- a/packages/redux-slice-factory/src/types/index.ts
+++ b/packages/redux-slice-factory/src/types/index.ts
@@ -1,4 +1,4 @@
-import { CaseReducerActions, Reducer, SliceCaseReducers } from '@reduxjs/toolkit'
+import { CaseReducer, CaseReducerActions, PayloadAction, Reducer, SerializedError, SliceCaseReducers } from '@reduxjs/toolkit'
 import StatusEnum from '../constants/StatusEnum'
 
 /**
@@ -39,10 +39,21 @@ export interface ISlice<
 export interface IMetaSliceSelectors<
     TGlobalState,
     TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
+    TError extends SerializedError = SerializedError
 > {
     selectStatus: (state: TGlobalState) => TStatusEnum;
     selectError: (state: TGlobalState) => TError | null;
     selectLastModified: (state: TGlobalState) => string | null;
     selectLastHydrated: (state: TGlobalState) => string | null;
+}
+
+/**
+ * @public
+ */
+ export type IMetaSliceReducers <TSliceState, TStatusEnum, TError> = {
+    reset: CaseReducer<TSliceState, PayloadAction>;
+    setStatus: CaseReducer<TSliceState, PayloadAction<TStatusEnum>>;
+    setError: CaseReducer<TSliceState, PayloadAction<TError | null>>;
+    succeed: CaseReducer<TSliceState, PayloadAction<TStatusEnum>>;
+    fail: CaseReducer<TSliceState, PayloadAction<{ status: TStatusEnum, error: TError | null }>>;
 }

--- a/packages/redux-slice-factory/src/utilities/index.ts
+++ b/packages/redux-slice-factory/src/utilities/index.ts
@@ -1,4 +1,4 @@
-import { SliceCaseReducers } from '@reduxjs/toolkit'
+import { SerializedError, SliceCaseReducers } from '@reduxjs/toolkit'
 import { ISlice, ISliceSelectors } from '../types'
 
 /**
@@ -19,7 +19,10 @@ export const getISOStringWithOffset = (dateTime: Date = new Date()): string => {
 /**
  * @internal
  */
-export const mapErrorToSerializableObject = <TError extends Error = Error> (error: TError): Record<keyof Error, string> => {
+export const mapErrorToSerializableObject = <TError extends SerializedError = SerializedError> (error: TError | null): TError | null => {
+    if (error === null) {
+        return null;
+    }
     const propertyNames = Object.getOwnPropertyNames(error)
     return propertyNames.reduce((accumulator, propertyName) => {
         const propertyDescriptorValue: unknown = Object.getOwnPropertyDescriptor(error, propertyName)?.value
@@ -27,7 +30,7 @@ export const mapErrorToSerializableObject = <TError extends Error = Error> (erro
             ...accumulator,
             [propertyName]: propertyDescriptorValue,
         }
-    }, {} as Record<keyof Error, string>)
+    }, {} as TError)
 }
 
 /**


### PR DESCRIPTION
 - Use `SerializedError` as base type instead of Error. This allows greater flexibility for `setError` as required properties are all now optional.
 - Use `mapErrorToSerializableObject` before error is stored in state. Was this an oversight? Because the docs claims errors are properly serialized before being stored. This will prevent any warnings from redux when Error instances are passed to `setError`.
 - Add `succeed` reducer to bundle a `setState` and `setError` in one call. Quite often this actions are used in conjunction and require a `batch` call each time.
 - Add `fail` for similar reason