### PR TITLE
setMetaState and serialized error

### DIFF
--- a/packages/redux-slice-factory/etc/redux-slice-factory.api.json
+++ b/packages/redux-slice-factory/etc/redux-slice-factory.api.json
@@ -210,8 +210,8 @@
             },
             {
               "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
+              "text": "SerializedError",
+              "canonicalReference": "@reduxjs/toolkit!SerializedError:interface"
             },
             {
               "kind": "Content",
@@ -223,8 +223,8 @@
             },
             {
               "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
+              "text": "SerializedError",
+              "canonicalReference": "@reduxjs/toolkit!SerializedError:interface"
             },
             {
               "kind": "Content",
@@ -361,8 +361,8 @@
             },
             {
               "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
+              "text": "SerializedError",
+              "canonicalReference": "@reduxjs/toolkit!SerializedError:interface"
             },
             {
               "kind": "Content",
@@ -374,8 +374,8 @@
             },
             {
               "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
+              "text": "SerializedError",
+              "canonicalReference": "@reduxjs/toolkit!SerializedError:interface"
             },
             {
               "kind": "Content",
@@ -478,59 +478,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export interface ICreateEntitySliceOptions<TGlobalState, TEntity, TStatusEnum extends "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": " | string "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": ", TError extends "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": "> "
+              "text": "export interface ICreateEntitySliceOptions<TGlobalState, TEntity, TStatusEnum, TError> "
             }
           ],
           "releaseTag": "Public",
@@ -560,23 +508,23 @@
             {
               "typeParameterName": "TStatusEnum",
               "constraintTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 7
+                "startIndex": 0,
+                "endIndex": 0
               }
             },
             {
               "typeParameterName": "TError",
               "constraintTokenRange": {
-                "startIndex": 8,
-                "endIndex": 10
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 0,
+                "endIndex": 0
               }
             }
           ],
@@ -860,59 +808,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export interface ICreateModelSliceOptions<TGlobalState, TModel, TStatusEnum extends "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": " | string "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": ", TError extends "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": "> "
+              "text": "export interface ICreateModelSliceOptions<TGlobalState, TModel, TStatusEnum, TError> "
             }
           ],
           "releaseTag": "Public",
@@ -942,23 +838,23 @@
             {
               "typeParameterName": "TStatusEnum",
               "constraintTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 7
+                "startIndex": 0,
+                "endIndex": 0
               }
             },
             {
               "typeParameterName": "TError",
               "constraintTokenRange": {
-                "startIndex": 8,
-                "endIndex": 10
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 0,
+                "endIndex": 0
               }
             }
           ],
@@ -1176,59 +1072,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type IEntitySlice<TGlobalState, TEntity, TStatusEnum extends "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": " | string "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": ", TError extends "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": "> = "
+              "text": "export declare type IEntitySlice<TGlobalState, TEntity, TStatusEnum, TError> = "
             },
             {
               "kind": "Reference",
@@ -1308,29 +1152,29 @@
             {
               "typeParameterName": "TStatusEnum",
               "constraintTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 7
+                "startIndex": 0,
+                "endIndex": 0
               }
             },
             {
               "typeParameterName": "TError",
               "constraintTokenRange": {
-                "startIndex": 8,
-                "endIndex": 10
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 0,
+                "endIndex": 0
               }
             }
           ],
           "typeTokenRange": {
-            "startIndex": 13,
-            "endIndex": 23
+            "startIndex": 1,
+            "endIndex": 11
           }
         },
         {
@@ -1821,7 +1665,43 @@
             },
             {
               "kind": "Content",
-              "text": "<TError | null>>;\n}"
+              "text": "<TError | null>>;\n    setMetaState: "
+            },
+            {
+              "kind": "Reference",
+              "text": "CaseReducer",
+              "canonicalReference": "@reduxjs/toolkit!CaseReducer:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<TSliceState, "
+            },
+            {
+              "kind": "Reference",
+              "text": "PayloadAction",
+              "canonicalReference": "@reduxjs/toolkit!PayloadAction:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "Partial",
+              "canonicalReference": "!Partial:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "IMetaState",
+              "canonicalReference": "@gjv/redux-slice-factory!IMetaState:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<TStatusEnum, TError>>>>;\n}"
             },
             {
               "kind": "Content",
@@ -1878,7 +1758,7 @@
           ],
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 108
+            "endIndex": 116
           }
         },
         {
@@ -1888,59 +1768,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export interface IEntitySliceSelectors<TGlobalState, TEntity, TStatusEnum extends "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": " | string "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": ", TError extends "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": "> extends "
+              "text": "export interface IEntitySliceSelectors<TGlobalState, TEntity, TStatusEnum, TError> extends "
             },
             {
               "kind": "Reference",
@@ -2014,23 +1842,23 @@
             {
               "typeParameterName": "TStatusEnum",
               "constraintTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 7
+                "startIndex": 0,
+                "endIndex": 0
               }
             },
             {
               "typeParameterName": "TError",
               "constraintTokenRange": {
-                "startIndex": 8,
-                "endIndex": 10
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 0,
+                "endIndex": 0
               }
             }
           ],
@@ -2038,16 +1866,16 @@
           "members": [],
           "extendsTokenRanges": [
             {
-              "startIndex": 13,
-              "endIndex": 15
+              "startIndex": 1,
+              "endIndex": 3
             },
             {
-              "startIndex": 16,
-              "endIndex": 20
+              "startIndex": 4,
+              "endIndex": 8
             },
             {
-              "startIndex": 21,
-              "endIndex": 23
+              "startIndex": 9,
+              "endIndex": 11
             }
           ]
         },
@@ -2058,59 +1886,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export interface IEntityState<T, TStatusEnum extends "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": " | string "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": ", TError extends "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": "> extends "
+              "text": "export interface IEntityState<T, TStatusEnum, TError> extends "
             },
             {
               "kind": "Reference",
@@ -2151,23 +1927,23 @@
             {
               "typeParameterName": "TStatusEnum",
               "constraintTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 7
+                "startIndex": 0,
+                "endIndex": 0
               }
             },
             {
               "typeParameterName": "TError",
               "constraintTokenRange": {
-                "startIndex": 8,
-                "endIndex": 10
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 0,
+                "endIndex": 0
               }
             }
           ],
@@ -2175,12 +1951,12 @@
           "members": [],
           "extendsTokenRanges": [
             {
-              "startIndex": 13,
-              "endIndex": 15
+              "startIndex": 1,
+              "endIndex": 3
             },
             {
-              "startIndex": 16,
-              "endIndex": 18
+              "startIndex": 4,
+              "endIndex": 6
             }
           ]
         },
@@ -2191,59 +1967,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export interface IMetaSliceSelectors<TGlobalState, TStatusEnum extends "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": " | string "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": ", TError extends "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": "> "
+              "text": "export interface IMetaSliceSelectors<TGlobalState, TStatusEnum, TError> "
             }
           ],
           "releaseTag": "Public",
@@ -2262,23 +1986,23 @@
             {
               "typeParameterName": "TStatusEnum",
               "constraintTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 7
+                "startIndex": 0,
+                "endIndex": 0
               }
             },
             {
               "typeParameterName": "TError",
               "constraintTokenRange": {
-                "startIndex": 8,
-                "endIndex": 10
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 0,
+                "endIndex": 0
               }
             }
           ],
@@ -2398,59 +2122,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export interface IMetaState<TStatusEnum extends "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": " | string "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": ", TError extends "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": "> "
+              "text": "export interface IMetaState<TStatusEnum, TError> "
             }
           ],
           "releaseTag": "Public",
@@ -2458,23 +2130,23 @@
             {
               "typeParameterName": "TStatusEnum",
               "constraintTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 7
+                "startIndex": 0,
+                "endIndex": 0
               }
             },
             {
               "typeParameterName": "TError",
               "constraintTokenRange": {
-                "startIndex": 8,
-                "endIndex": 10
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 0,
+                "endIndex": 0
               }
             }
           ],
@@ -2594,59 +2266,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type IModelSlice<TGlobalState, TModel, TStatusEnum extends "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": " | string "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": ", TError extends "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": "> = "
+              "text": "export declare type IModelSlice<TGlobalState, TModel, TStatusEnum, TError> = "
             },
             {
               "kind": "Reference",
@@ -2726,29 +2346,29 @@
             {
               "typeParameterName": "TStatusEnum",
               "constraintTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 7
+                "startIndex": 0,
+                "endIndex": 0
               }
             },
             {
               "typeParameterName": "TError",
               "constraintTokenRange": {
-                "startIndex": 8,
-                "endIndex": 10
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 0,
+                "endIndex": 0
               }
             }
           ],
           "typeTokenRange": {
-            "startIndex": 13,
-            "endIndex": 23
+            "startIndex": 1,
+            "endIndex": 11
           }
         },
         {
@@ -2879,7 +2499,43 @@
             },
             {
               "kind": "Content",
-              "text": "<TError | null>>;\n}"
+              "text": "<TError | null>>;\n    setMetaState: "
+            },
+            {
+              "kind": "Reference",
+              "text": "CaseReducer",
+              "canonicalReference": "@reduxjs/toolkit!CaseReducer:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<TSliceState, "
+            },
+            {
+              "kind": "Reference",
+              "text": "PayloadAction",
+              "canonicalReference": "@reduxjs/toolkit!PayloadAction:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "Partial",
+              "canonicalReference": "!Partial:type"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "IMetaState",
+              "canonicalReference": "@gjv/redux-slice-factory!IMetaState:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<TStatusEnum, TError>>>>;\n}"
             },
             {
               "kind": "Content",
@@ -2936,7 +2592,7 @@
           ],
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 28
+            "endIndex": 36
           }
         },
         {
@@ -2946,59 +2602,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export interface IModelSliceSelectors<TGlobalState, TModel, TStatusEnum extends "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": " | string "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": ", TError extends "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": "> extends "
+              "text": "export interface IModelSliceSelectors<TGlobalState, TModel, TStatusEnum, TError> extends "
             },
             {
               "kind": "Reference",
@@ -3059,23 +2663,23 @@
             {
               "typeParameterName": "TStatusEnum",
               "constraintTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 7
+                "startIndex": 0,
+                "endIndex": 0
               }
             },
             {
               "typeParameterName": "TError",
               "constraintTokenRange": {
-                "startIndex": 8,
-                "endIndex": 10
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 0,
+                "endIndex": 0
               }
             }
           ],
@@ -3110,12 +2714,12 @@
           ],
           "extendsTokenRanges": [
             {
-              "startIndex": 13,
-              "endIndex": 17
+              "startIndex": 1,
+              "endIndex": 5
             },
             {
-              "startIndex": 18,
-              "endIndex": 20
+              "startIndex": 6,
+              "endIndex": 8
             }
           ]
         },
@@ -3126,59 +2730,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export interface IModelState<T, TStatusEnum extends "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": " | string "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Content",
-              "text": "keyof typeof "
-            },
-            {
-              "kind": "Reference",
-              "text": "StatusEnum",
-              "canonicalReference": "@gjv/redux-slice-factory!~StatusEnum:enum"
-            },
-            {
-              "kind": "Content",
-              "text": ", TError extends "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " "
-            },
-            {
-              "kind": "Content",
-              "text": "= "
-            },
-            {
-              "kind": "Reference",
-              "text": "Error",
-              "canonicalReference": "!Error:interface"
-            },
-            {
-              "kind": "Content",
-              "text": "> extends "
+              "text": "export interface IModelState<T, TStatusEnum, TError> extends "
             },
             {
               "kind": "Reference",
@@ -3206,23 +2758,23 @@
             {
               "typeParameterName": "TStatusEnum",
               "constraintTokenRange": {
-                "startIndex": 1,
-                "endIndex": 4
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 7
+                "startIndex": 0,
+                "endIndex": 0
               }
             },
             {
               "typeParameterName": "TError",
               "constraintTokenRange": {
-                "startIndex": 8,
-                "endIndex": 10
+                "startIndex": 0,
+                "endIndex": 0
               },
               "defaultTypeTokenRange": {
-                "startIndex": 11,
-                "endIndex": 12
+                "startIndex": 0,
+                "endIndex": 0
               }
             }
           ],
@@ -3257,8 +2809,8 @@
           ],
           "extendsTokenRanges": [
             {
-              "startIndex": 13,
-              "endIndex": 15
+              "startIndex": 1,
+              "endIndex": 3
             }
           ]
         },

--- a/packages/redux-slice-factory/etc/redux-slice-factory.api.md
+++ b/packages/redux-slice-factory/etc/redux-slice-factory.api.md
@@ -12,17 +12,18 @@ import { EntitySelectors } from '@reduxjs/toolkit';
 import { EntityState } from '@reduxjs/toolkit';
 import { PayloadAction } from '@reduxjs/toolkit';
 import { Reducer } from '@reduxjs/toolkit';
+import { SerializedError } from '@reduxjs/toolkit';
 import { SliceCaseReducers } from '@reduxjs/toolkit';
 import { Update } from '@reduxjs/toolkit';
 
 // @public (undocumented)
-export function createEntitySlice<TGlobalState, TEntity, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error>(options: ICreateEntitySliceOptions<TGlobalState, TEntity, TStatusEnum, TError>): IEntitySlice<TGlobalState, TEntity, TStatusEnum, TError>;
+export function createEntitySlice<TGlobalState, TEntity, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends SerializedError = SerializedError>(options: ICreateEntitySliceOptions<TGlobalState, TEntity, TStatusEnum, TError>): IEntitySlice<TGlobalState, TEntity, TStatusEnum, TError>;
 
 // @public (undocumented)
-export function createModelSlice<TGlobalState, TModel, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error>(options: ICreateModelSliceOptions<TGlobalState, TModel, TStatusEnum, TError>): IModelSlice<TGlobalState, TModel, TStatusEnum, TError>;
+export function createModelSlice<TGlobalState, TModel, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends SerializedError = SerializedError>(options: ICreateModelSliceOptions<TGlobalState, TModel, TStatusEnum, TError>): IModelSlice<TGlobalState, TModel, TStatusEnum, TError>;
 
 // @public (undocumented)
-export interface ICreateEntitySliceOptions<TGlobalState, TEntity, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error> {
+export interface ICreateEntitySliceOptions<TGlobalState, TEntity, TStatusEnum, TError> {
     // (undocumented)
     debug?: boolean;
     // (undocumented)
@@ -44,7 +45,7 @@ export interface ICreateEntitySliceOptions<TGlobalState, TEntity, TStatusEnum ex
 }
 
 // @public (undocumented)
-export interface ICreateModelSliceOptions<TGlobalState, TModel, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error> {
+export interface ICreateModelSliceOptions<TGlobalState, TModel, TStatusEnum, TError> {
     // (undocumented)
     debug?: boolean;
     // (undocumented)
@@ -60,7 +61,7 @@ export interface ICreateModelSliceOptions<TGlobalState, TModel, TStatusEnum exte
 }
 
 // @public (undocumented)
-export type IEntitySlice<TGlobalState, TEntity, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error> = ISlice<TGlobalState, IEntityState<TEntity, TStatusEnum, TError>, IEntitySliceReducers<IEntityState<TEntity, TStatusEnum, TError>, TEntity, TStatusEnum, TError>, IEntitySliceSelectors<TGlobalState, TEntity, TStatusEnum, TError>>;
+export type IEntitySlice<TGlobalState, TEntity, TStatusEnum, TError> = ISlice<TGlobalState, IEntityState<TEntity, TStatusEnum, TError>, IEntitySliceReducers<IEntityState<TEntity, TStatusEnum, TError>, TEntity, TStatusEnum, TError>, IEntitySliceSelectors<TGlobalState, TEntity, TStatusEnum, TError>>;
 
 // @public (undocumented)
 export type IEntitySliceReducers<TSliceState, TEntity, TStatusEnum, TError> = {
@@ -80,18 +81,19 @@ export type IEntitySliceReducers<TSliceState, TEntity, TStatusEnum, TError> = {
     setAll: CaseReducer<TSliceState, PayloadAction<Array<TEntity> | Record<EntityId, TEntity>>>;
     setStatus: CaseReducer<TSliceState, PayloadAction<TStatusEnum>>;
     setError: CaseReducer<TSliceState, PayloadAction<TError | null>>;
+    setMetaState: CaseReducer<TSliceState, PayloadAction<Partial<IMetaState<TStatusEnum, TError>>>>;
 };
 
 // @public (undocumented)
-export interface IEntitySliceSelectors<TGlobalState, TEntity, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error> extends EntitySelectors<TEntity, TGlobalState>, ISliceSelectors<TGlobalState, IEntityState<TEntity, TStatusEnum, TError>>, IMetaSliceSelectors<TGlobalState, TStatusEnum, TError> {
+export interface IEntitySliceSelectors<TGlobalState, TEntity, TStatusEnum, TError> extends EntitySelectors<TEntity, TGlobalState>, ISliceSelectors<TGlobalState, IEntityState<TEntity, TStatusEnum, TError>>, IMetaSliceSelectors<TGlobalState, TStatusEnum, TError> {
 }
 
 // @public (undocumented)
-export interface IEntityState<T, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error> extends EntityState<T>, IMetaState<TStatusEnum, TError> {
+export interface IEntityState<T, TStatusEnum, TError> extends EntityState<T>, IMetaState<TStatusEnum, TError> {
 }
 
 // @public (undocumented)
-export interface IMetaSliceSelectors<TGlobalState, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error> {
+export interface IMetaSliceSelectors<TGlobalState, TStatusEnum, TError> {
     // (undocumented)
     selectError: (state: TGlobalState) => TError | null;
     // (undocumented)
@@ -103,7 +105,7 @@ export interface IMetaSliceSelectors<TGlobalState, TStatusEnum extends keyof typ
 }
 
 // @public (undocumented)
-export interface IMetaState<TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error> {
+export interface IMetaState<TStatusEnum, TError> {
     // (undocumented)
     error: TError | null;
     // (undocumented)
@@ -115,7 +117,7 @@ export interface IMetaState<TStatusEnum extends keyof typeof StatusEnum | string
 }
 
 // @public (undocumented)
-export type IModelSlice<TGlobalState, TModel, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error> = ISlice<TGlobalState, IModelState<TModel, TStatusEnum, TError>, IModelSliceReducers<IModelState<TModel, TStatusEnum, TError>, TModel, TStatusEnum, TError>, IModelSliceSelectors<TGlobalState, TModel, TStatusEnum, TError>>;
+export type IModelSlice<TGlobalState, TModel, TStatusEnum, TError> = ISlice<TGlobalState, IModelState<TModel, TStatusEnum, TError>, IModelSliceReducers<IModelState<TModel, TStatusEnum, TError>, TModel, TStatusEnum, TError>, IModelSliceSelectors<TGlobalState, TModel, TStatusEnum, TError>>;
 
 // @public (undocumented)
 export type IModelSliceReducers<TSliceState, TModel, TStatusEnum, TError> = {
@@ -125,16 +127,17 @@ export type IModelSliceReducers<TSliceState, TModel, TStatusEnum, TError> = {
     reset: CaseReducer<TSliceState, PayloadAction>;
     setStatus: CaseReducer<TSliceState, PayloadAction<TStatusEnum>>;
     setError: CaseReducer<TSliceState, PayloadAction<TError | null>>;
+    setMetaState: CaseReducer<TSliceState, PayloadAction<Partial<IMetaState<TStatusEnum, TError>>>>;
 };
 
 // @public (undocumented)
-export interface IModelSliceSelectors<TGlobalState, TModel, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error> extends ISliceSelectors<TGlobalState, IModelState<TModel, TStatusEnum, TError>>, IMetaSliceSelectors<TGlobalState, TStatusEnum, TError> {
+export interface IModelSliceSelectors<TGlobalState, TModel, TStatusEnum, TError> extends ISliceSelectors<TGlobalState, IModelState<TModel, TStatusEnum, TError>>, IMetaSliceSelectors<TGlobalState, TStatusEnum, TError> {
     // (undocumented)
     selectModel: (state: TGlobalState) => TModel;
 }
 
 // @public (undocumented)
-export interface IModelState<T, TStatusEnum extends keyof typeof StatusEnum | string = keyof typeof StatusEnum, TError extends Error = Error> extends IMetaState<TStatusEnum, TError> {
+export interface IModelState<T, TStatusEnum, TError> extends IMetaState<TStatusEnum, TError> {
     // (undocumented)
     model: T;
 }

--- a/packages/redux-slice-factory/src/models/entity-state/EntityState.ts
+++ b/packages/redux-slice-factory/src/models/entity-state/EntityState.ts
@@ -1,20 +1,16 @@
-import { EntityState as ReduxEntityState } from '@reduxjs/toolkit'
+import { EntityState as ReduxEntityState, SerializedError } from '@reduxjs/toolkit'
 import StatusEnum from '../../constants/StatusEnum'
 import MetaState, { IMetaState } from '../meta-state'
 
 /**
  * @public
  */
-export interface IEntityState<
-    T,
-    TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
-> extends ReduxEntityState<T>, IMetaState<TStatusEnum, TError> {}
+export interface IEntityState<T, TStatusEnum, TError> extends ReduxEntityState<T>, IMetaState<TStatusEnum, TError> {}
 
 const create = <
     T,
     TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
+    TError extends SerializedError = SerializedError
 > (args: Partial<IEntityState<T, TStatusEnum, TError>> = {}): IEntityState<T, TStatusEnum, TError> => {
     const metaState = MetaState.create(args)
     return {

--- a/packages/redux-slice-factory/src/models/meta-state/MetaState.ts
+++ b/packages/redux-slice-factory/src/models/meta-state/MetaState.ts
@@ -1,9 +1,10 @@
+import { SerializedError } from '@reduxjs/toolkit'
 import StatusEnum from '../../constants/StatusEnum'
 
 /**
  * @public
  */
-export interface IMetaState <TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum, TError extends Error = Error> {
+export interface IMetaState <TStatusEnum, TError> {
     status: TStatusEnum;
     error: TError | null;
     lastModified: string | null;
@@ -12,7 +13,7 @@ export interface IMetaState <TStatusEnum extends keyof typeof StatusEnum | & str
 
 const create = <
     TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
+    TError extends SerializedError = SerializedError
 > (args: Partial<IMetaState<TStatusEnum, TError>> = {}): IMetaState<TStatusEnum, TError> => ({
     status: args.status ?? StatusEnum.Settled as TStatusEnum,
     error: args.error ?? null,

--- a/packages/redux-slice-factory/src/models/model-state/ModelState.ts
+++ b/packages/redux-slice-factory/src/models/model-state/ModelState.ts
@@ -1,21 +1,18 @@
+import { SerializedError } from '@reduxjs/toolkit'
 import StatusEnum from '../../constants/StatusEnum'
 import MetaState, { IMetaState } from '../meta-state'
 
 /**
  * @public
  */
-export interface IModelState<
-    T,
-    TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
-> extends IMetaState<TStatusEnum, TError> {
+export interface IModelState<T, TStatusEnum, TError> extends IMetaState<TStatusEnum, TError> {
     model: T;
 }
 
 const create = <
     T,
     TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
+    TError extends SerializedError = SerializedError
 > (args: Partial<IModelState<T, TStatusEnum, TError>> = {}): IModelState<T, TStatusEnum, TError> => {
     const metaState = MetaState.create(args)
     return {

--- a/packages/redux-slice-factory/src/types/index.ts
+++ b/packages/redux-slice-factory/src/types/index.ts
@@ -38,8 +38,8 @@ export interface ISlice<
  */
 export interface IMetaSliceSelectors<
     TGlobalState,
-    TStatusEnum extends keyof typeof StatusEnum | & string = keyof typeof StatusEnum,
-    TError extends Error = Error
+    TStatusEnum,
+    TError
 > {
     selectStatus: (state: TGlobalState) => TStatusEnum;
     selectError: (state: TGlobalState) => TError | null;


### PR DESCRIPTION
Add `setMetaState` reducer to modify meta data of slice in one action
Remove unnecessary typings and use serialized error